### PR TITLE
Fix Invalid index

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ module "vpc" {
 
 locals {
   vpc_subnets = {
+    default = [
+      {
+        "v4_cidr_blocks": [
+          "10.127.0.0/24"
+        ],
+        "zone": var.yc_region
+      }
+    ]
     stage = [
       {
         "v4_cidr_blocks": [


### PR DESCRIPTION
│ Error: 
│
│   on main.tf line 24, in module "vpc":
│   24:   subnets = local.vpc_subnets[terraform.workspace]
│     ├────────────────
│     │ local.vpc_subnets is object with 2 attributes
│     │ terraform.workspace is "default"
│
│ The given key does not identify an element in this collection value.